### PR TITLE
Limit dependency gem versions

### DIFF
--- a/lib/seoable/version.rb
+++ b/lib/seoable/version.rb
@@ -1,3 +1,3 @@
 module Seoable
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/seoable.gemspec
+++ b/seoable.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'friendly_id'
-  spec.add_dependency 'rails'
+  spec.add_dependency 'friendly_id', '~> 5.1.0'
+  spec.add_dependency 'rails', '~> 4.2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'combustion'


### PR DESCRIPTION
* FriendlyId gem v5.3.0 is not compatible with current implementation of
  seoable