### PR TITLE
Acts as seoable fixes

### DIFF
--- a/app/models/concerns/seoable/acts_as_seoable.rb
+++ b/app/models/concerns/seoable/acts_as_seoable.rb
@@ -16,32 +16,26 @@ module Seoable
               dependent: :destroy,
               class_name: SeoDetail
 
-      accepts_nested_attributes_for :seo_detail
+      accepts_nested_attributes_for :seo_detail, reject_if: :all_blank
 
       delegate :meta_title, to: :seo_detail, allow_nil: true
       delegate :meta_description, to: :seo_detail, allow_nil: true
       delegate :slug, to: :seo_detail, allow_nil: true
+    end
 
-      before_validation :build_seo_detail
+    def seo_detail
+      super || build_seo_detail(seo_detail_attributes)
+    end
+
+    def seo_detail_attributes
+      {
+        meta_title: sluggable,
+        seoable: self,
+        slug: sluggable.to_slug
+      }
     end
 
     private
-
-      def build_seo_detail
-        if seo_detail.blank?
-          super(seo_detail_attributes)
-        else
-          seo_detail.assign_attributes(seo_detail_attributes)
-        end
-      end
-
-      def seo_detail_attributes
-        {
-          meta_title: sluggable,
-          seoable: self,
-          slug: sluggable.to_slug
-        }
-      end
 
       def sluggable
         attribute = Seoable.configuration

--- a/app/models/concerns/seoable/acts_as_seoable.rb
+++ b/app/models/concerns/seoable/acts_as_seoable.rb
@@ -42,12 +42,7 @@ module Seoable
                     .sluggable_attributes.find do |sluggable_attribute|
                       self.respond_to?(sluggable_attribute)
                     end
-
-        if attribute.present?
-          send(attribute).to_s
-        else
-          Seoable.configuration.sluggable_attributes.first.to_s
-        end
+        send(attribute).to_s
       end
   end
 end

--- a/app/models/concerns/seoable/acts_as_seoable.rb
+++ b/app/models/concerns/seoable/acts_as_seoable.rb
@@ -50,7 +50,7 @@ module Seoable
                     end
 
         if attribute.present?
-          send(attribute)
+          send(attribute).to_s
         else
           Seoable.configuration.sluggable_attributes.first.to_s
         end

--- a/spec/shared/acts_as_seoable.rb
+++ b/spec/shared/acts_as_seoable.rb
@@ -53,13 +53,6 @@ module Seoable
 
     context 'update model' do
       context 'without seo detail' do
-        before(:each) do
-          described_class.skip_callback(:validation, :before, :build_seo_detail)
-          model_instance.save
-          described_class.set_callback(:validation, :before, :build_seo_detail)
-          expect(model_instance.seo_detail).to be nil
-        end
-
         it 'creates seo detail' do
           expect{model_instance.save}.to change(SeoDetail, :count).by(1)
         end


### PR DESCRIPTION
This pull request fixes the following issues:

* build_seo_detail was a private method and therefore could not be called on an instance of the object

* parameterize was being called on Nil objects